### PR TITLE
Feature/use Action Term and support multi tables for trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # edgeml
 
-It is common for edge device to be limited by GPU compute. This library enables distributed datastream from edge device to GPU compute for various ml applications. The lib mainly based on client-server architecutre, enable simple TCP communication between multiple clients to server.
+A simple framework for distributed machine learning library for edge computing. It is common for edge device to be limited by GPU compute. This library enables distributed datastream from edge device to GPU compute for various ml applications. The lib mainly based on client-server architecutre, enable simple TCP communication between multiple clients to server.
 
 ## Installation
 
@@ -24,22 +24,24 @@ python3 example.py --client
 
 ## Architecture
 
-There are three types of server-client main types of classes for user to use, according to their application. Functional programming is mainly used as the API design. User can define their own callback function to process the data.
+There are three types of server-client main types of classes for user to use, according to their application. Functional programming is mainly used as the API design. User can define their own callback function to process the data. There are mainly 3 modes: `env`, `inference`, `trainer`.
 
-1. **Actor (edge device) as server: `edgeml.ActorServer` and `edgeml.ActorClient`**
-   - `ActorServer` provides observation to client
-   - `ActorClient` can provide further action to server (Optional)
+1. **Action service (edge device) as server: `edgeml.ActionServer` and `edgeml.ActionClient`**
+   - `ActionServer` provides observation to client
+   - `ActionClient` can provide further action to server (Optional)
+
+For a Reinforcement learning setting, this action server can be considered as a `EnvServer`, which takes in action and return obs. The term of `ActionServer` is to make it more general for other applications other than RL.
 
 *Multi-clients can connect to a edge server. client can call `obs`, `act` impl, and server can call `publish_obs` method. The method is shown in the diagram below.*
 
 ```mermaid
 graph LR
-A[Clients] -- "obs()" --> B((Edge Server))
+A[Clients] -- "obs()" --> B((Action Server))
 A -- "act()" --> B
 B -- "publish_obs()" --> A
 ```
 
-2. **Inference compute as server: `edgeml.InferenceServer` and `edgeml.InferenceClient`**
+1. **Inference compute as server: `edgeml.InferenceServer` and `edgeml.InferenceClient`**
    - `InferenceClient` provides observation to server and gets prediction
 
 *Multi-client to call inference compute. client can call the `call` method*
@@ -70,12 +72,12 @@ A -- "send_request()" --> B
 
 1. **Edge Device as Server**
 
-An edge device (Agent) can send observations to a remote client. The client, in turn, can provide actions to the agent based on these observations. This uses the `edgeml.ActorServer` and `edgeml.ActorClient` classes.
+An edge device (Agent) can send observations to a remote client. The client, in turn, can provide actions to the agent based on these observations. This uses the `edgeml.ActionServer` and `edgeml.ActionClient` classes.
 
 **GPU Compute as client**
 ```py
 model = load_model()
-agent = edgeml.ActorClient('localhost', 6379, task_id='mnist', config=agent_config)
+agent = edgeml.ActionClient('localhost', 6379, task_id='mnist', config=agent_config)
 
 for _ in range(100):
     observation = agent.get_observation()
@@ -93,8 +95,8 @@ def observation_callback(keys):
     # TODO: return the desired observations here
     return {"cam1": "some_value"}
 
-config = edgeml.ActorConfig(port_number=6379, action_keys=['move'], observation_keys=['cam1'])
-agent_server = edgeml.ActorServer(config, observation_callback, action_callback)
+config = edgeml.ActionConfig(port_number=6379, action_keys=['move'], observation_keys=['cam1'])
+agent_server = edgeml.ActionServer(config, observation_callback, action_callback)
 agent_server.start()
 ```
 
@@ -158,7 +160,7 @@ trainer_server.start()
 - Run test cases to make sure everything is working as expected.
 
 ```bash
-python3 edgeml/tests/test_actor.py
+python3 edgeml/tests/test_action.py
 python3 edgeml/tests/test_inference.py
 python3 edgeml/tests/test_trainer.py
 

--- a/edgeml/interfaces.py
+++ b/edgeml/interfaces.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
 from typing import Optional, Callable, Set, Dict, List
 from typing_extensions import Protocol
 from collections import deque
@@ -13,12 +14,14 @@ import threading
 import logging
 from pydantic import BaseModel
 import json
+import pickle
+
 
 ##############################################################################
 
 
-class ActorConfig(BaseModel):
-    """Configuration for the edge server and client
+class ActionConfig(BaseModel):
+    """Configuration for the env server and client
     NOTE: Client and server should have the same config
             client will raise Error if configs are different, thus can use
             `version` to check for compatibility
@@ -34,7 +37,7 @@ class ObsCallback(Protocol):
     """
     Define the data type of the callback function
         :param keys: Set of keys of the observation, defaults to all keys
-        :return: Response to send to the client
+        :return: Response with Observation to send to the client
     """
 
     def __call__(self, keys: Set) -> Dict:
@@ -55,9 +58,9 @@ class ActCallback(Protocol):
 ##############################################################################
 
 
-class ActorServer:
+class ActionServer:
     def __init__(self,
-                 config: ActorConfig,
+                 config: ActionConfig,
                  obs_callback: Optional[ObsCallback],
                  act_callback: Optional[ActCallback],
                  log_level=logging.DEBUG):
@@ -74,13 +77,13 @@ class ActorServer:
                 return act_callback(payload["key"], payload["payload"])
             elif payload["type"] == "hash":
                 config_json = json.dumps(config.dict(), separators=(',', ':'))
-                return {"status": "success", "payload": config_json}
-            return {"status": "error", "message": "Invalid payload"}
+                return {"success": True, "payload": config_json}
+            return {"success": False, "message": "Invalid payload"}
 
         self.config = config
         self.server = ReqRepServer(config.port_number, __obs_parser_cb)
         logging.basicConfig(level=log_level)
-        logging.debug(f"Edge server is listening on port {config.port_number}")
+        logging.debug(f"Action server is listening on port {config.port_number}")
 
         if config.broadcast_port is not None:
             self.broadcast = BroadcastServer(config.broadcast_port)
@@ -100,7 +103,7 @@ class ActorServer:
     def publish_obs(self, payload: dict) -> bool:
         """
         Publishes the observation to the broadcast server,
-        Enable broadcasting by defining `broadcast_port` in `ActorConfig`
+        Enable broadcasting by defining `broadcast_port` in `ActionConfig`
         """
         if self.config.broadcast_port is None:
             logging.warning("Broadcast server not initialized")
@@ -115,13 +118,13 @@ class ActorServer:
 ##############################################################################
 
 
-class ActorClient:
-    def __init__(self, server_ip: str, config: ActorConfig):
+class ActionClient:
+    def __init__(self, server_ip: str, config: ActionConfig):
         self.client = ReqRepClient(server_ip, config.port_number)
         # Check hash of server config to ensure compatibility
         res = self.client.send_msg({"type": "hash"})
         if res is None:
-            raise Exception("Failed to connect to server")
+            raise Exception("Failed to connect to action server")
 
         config_json = json.dumps(config.dict(), separators=(',', ':'))
         if compute_hash(config_json) != compute_hash(res["payload"]):
@@ -195,7 +198,7 @@ class InferenceServer:
                 interface_name = payload.get('interface')
                 if interface_name and interface_name in self.interfaces:
                     return self.interfaces[interface_name](payload['payload'])
-            return {"status": "error", "message": "Invalid interface or payload"}
+            return {"success": False, "message": "Invalid interface or payload"}
 
         self.server = ReqRepServer(port_num, __parser_cb)
         self.interfaces = {}
@@ -253,6 +256,13 @@ class InferenceClient:
 ##############################################################################
 
 
+class DataTable(BaseModel):
+    """Data table to store data or replay buffer"""
+    name: str
+    size: int = 5
+    fifo: bool = True  # use maxheap if false, not implemented yet
+
+
 class TrainerConfig(BaseModel):
     """
     Configuration for the edge server and client
@@ -262,7 +272,7 @@ class TrainerConfig(BaseModel):
     """
     port_number: int
     broadcast_port: int
-    queue_size: int = 1
+    data_table: List[DataTable]
     request_types: List[str] = []
     rate_limit: Optional[int] = None
     version: str = "0.0.1"
@@ -308,32 +318,48 @@ class TrainerServer:
         """
         self.queue = deque()  # FIFO queue
         self.request_types = set(config.request_types)  # faster lookup
+        self.data_store = {}
+        self.config = config
+
+        for _ds in config.data_table:
+            self.data_store[_ds.name] = deque(maxlen=_ds.size)
 
         def __callback_impl(data: dict) -> dict:
             _type, _payload = data.get("type"), data.get("payload")
             if _type == "data":
-                if len(self.queue) >= config.queue_size:
-                    self.queue.popleft()
-                self.queue.append(_payload)
+                table_name = data.get("table_name")
+                if table_name not in self.data_store:
+                    return {"success": False, "message": "Invalid table name"}
+                self.data_store[table_name].append(_payload)
                 return train_callback(_payload)
             elif _type == "hash":
-                print("hash", config.json())
+                # print("config", config.json())
                 config_json = json.dumps(config.dict(), separators=(',', ':'))
-                return {"status": "success", "payload": config_json}
+                return {"success": True, "payload": config_json}
             elif _type in self.request_types:
                 return request_callback(_type, _payload) if request_callback else {}
-            return {"status": "error", "message": "Invalid type or payload"}
+            return {"success": False, "message": "Invalid type or payload"}
 
         self.req_rep_server = ReqRepServer(config.port_number, __callback_impl)
         self.broadcast_server = BroadcastServer(config.broadcast_port)
         logging.basicConfig(level=log_level)
         logging.debug(f"Trainer server is listening on port {config.port_number}")
 
-    def get_data(self) -> List[dict]:
+    def table_names(self) -> Set[str]:
+        """
+        Returns the set of table names available on the server
+            :return: Set of table names available on the server
+        """
+        return set(self.data_store.keys())
+
+    def get_data(self, table_name: str) -> Optional[List[dict]]:
         """
         Get the list of training data, max size is `config.queue_size`
+            :return: List of training data,
+                     return None if table_name is invalid
         """
-        return list(self.queue)
+        data = self.data_store.get(table_name, None)
+        return None if data is None else list(data)
 
     def publish_weights(self, payload: dict):
         """
@@ -352,9 +378,35 @@ class TrainerServer:
         else:
             self.req_rep_server.run()
 
+    def save_data(self, file_name: str):
+        """save the data to a pkl file"""
+        _save_data = {"config": self.config, "data_store": self.data_store}
+        with open(file_name, "wb") as f:
+            pickle.dump(_save_data, f)
+
     def stop(self):
         """Stop the server"""
         self.req_rep_server.stop()
+
+    @staticmethod
+    def make_from_file(file_name: str,
+                       train_callback,
+                       request_callback: Optional[RequestCallback] = None,
+                       log_level=logging.DEBUG) -> TrainerServer:
+        """
+        Load the and construct TrainerServer from a previously saved pkl file
+            :return: TrainerServer object, None if failed to load
+        """
+        try:
+            with open(file_name, "rb") as f:
+                file = pickle.load(f)
+            server = TrainerServer(
+                file["config"], train_callback, request_callback, log_level)
+            server.data_store = file["data_store"]  # load data
+            return server
+        except Exception as e:
+            logging.error(f"Failed to load file: {e}")
+        return None
 
 ##############################################################################
 
@@ -374,6 +426,7 @@ class TrainerClient:
         self.server_ip = server_ip
         self.config = config
         self.request_types = set(config.request_types)  # faster lookup
+        self.table_names = set([_ds.name for _ds in config.data_table])
 
         res = self.req_rep_client.send_msg({"type": "hash"})
         if res is None:
@@ -388,15 +441,19 @@ class TrainerClient:
         logging.debug(
             f"Initiated trainer client at {server_ip}:{config.port_number}")
 
-    def train_step(self, data: dict) -> Optional[dict]:
+    def train_step(self, table_name: str, data: dict) -> Optional[dict]:
         """
         Performs a training step with the given payload.
         NOTE: This is a blocking call. If the trainer needs more time to process,
         use the publish_weights() method in the server instead.
+            :param table_name: Name of the table to store the data
             :param data: Payload to send to the trainer
             :return: Response from the trainer, return None if timeout
         """
-        msg = {"type": "data", "payload": data}
+        if table_name not in self.table_names:
+            raise Exception(f"Invalid table name: {table_name}")
+
+        msg = {"type": "data", "table_name": table_name, "payload": data}
         if self.config.rate_limit and \
                 time.time() - self.last_request_time < 1 / self.config.rate_limit:
             logging.warning("Rate limit exceeded")
@@ -407,6 +464,7 @@ class TrainerClient:
     def request(self, type: str, payload: dict) -> Optional[dict]:
         """
         Call the trainer server with custom requests
+        Some common use cases: checkpointing, get-stats, etc.
             :param type: Name of the custom request, defined in `config.request_types`
             :param payload: Payload to send to the trainer
             :return: Response from the trainer, return None if timeout

--- a/edgeml/interfaces.py
+++ b/edgeml/interfaces.py
@@ -281,11 +281,12 @@ class TrainerConfig(BaseModel):
 class TrainerCallback(Protocol):
     """
     Define the data type of the trainer callback function
+        :param table_name: Name of the table to store the data
         :param payload: Payload to send to the trainer, e.g. training data
         :return: Response to send to the client, can return updated weights.
     """
 
-    def __call__(self, payload: dict) -> dict:
+    def __call__(self, table_name, payload: dict) -> dict:
         ...
 
 
@@ -331,7 +332,7 @@ class TrainerServer:
                 if table_name not in self.data_store:
                     return {"success": False, "message": "Invalid table name"}
                 self.data_store[table_name].append(_payload)
-                return train_callback(_payload)
+                return train_callback(table_name, _payload)
             elif _type == "hash":
                 # print("config", config.json())
                 config_json = json.dumps(config.dict(), separators=(',', ':'))

--- a/edgeml/internal/utils.py
+++ b/edgeml/internal/utils.py
@@ -3,6 +3,17 @@
 import hashlib
 import pickle
 import sys
+import numpy as np
+import cv2
+
+def mat_to_jpeg(img):
+    """Compresses a numpy array into a JPEG byte array."""
+    _, buf = cv2.imencode(".jpg", img)
+    return buf.tobytes()
+
+def jpeg_to_mat(buf):
+    """Decompresses a JPEG byte array into a numpy array."""
+    return cv2.imdecode(np.frombuffer(buf, dtype=np.uint8), cv2.IMREAD_COLOR)
 
 def compute_hash(obj):
     pickle_str = pickle.dumps(obj)

--- a/edgeml/tests/test_action.py
+++ b/edgeml/tests/test_action.py
@@ -3,9 +3,9 @@
 import cv2
 import time
 import logging
-from edgeml.interfaces import ActorClient, ActorServer, ActorConfig
+from edgeml.interfaces import ActionClient, ActionServer, ActionConfig
 
-def test_actor():
+def test_action():
     # 1. Read the image using OpenCV
     img = cv2.imread("edgeml/tests/test_image.png")
 
@@ -22,22 +22,22 @@ def test_actor():
         return {"status": "error", "message": "Invalid action"}
 
     # Define our config
-    config = ActorConfig(
+    config = ActionConfig(
         port_number=5555,
         action_keys=['send_image'],
         observation_keys=['test_image'],
         broadcast_port=5556
     )
 
-    # Initialize and start the ActorServer in a separate thread
-    server = ActorServer(config, obs_callback, act_callback)
+    # Initialize and start the ActionServer in a separate thread
+    server = ActionServer(config, obs_callback, act_callback)
     server.start(threaded=True)
 
     # Give the server a moment to start up
     time.sleep(2)
 
-    # Initialize the ActorClient
-    client = ActorClient('127.0.0.1', config)
+    # Initialize the ActionClient
+    client = ActionClient('127.0.0.1', config)
 
     # Define the callback for the client to handle broadcasted data
     received_broadcast = False
@@ -62,11 +62,12 @@ def test_actor():
     assert received_broadcast, "Client did not receive broadcasted data"
 
     # Clean up
+    print("[test_action] Cleaning up...")
     server.stop()
     client.stop()
 
-    print("[test_actor] All tests passed!")
+    print("[test_action] All tests passed!")
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    test_actor()
+    test_action()

--- a/edgeml/tests/test_all.py
+++ b/edgeml/tests/test_all.py
@@ -2,10 +2,10 @@
 
 from edgeml.tests.test_trainer import test_trainer
 from edgeml.tests.test_inference import test_inference
-from edgeml.tests.test_actor import test_actor
+from edgeml.tests.test_action import test_action
 
 if __name__ == '__main__':
-    test_actor()
+    test_action()
     test_inference()
     test_trainer()
     print(" [EdgeML] All tests passed!")

--- a/edgeml/tests/test_trainer.py
+++ b/edgeml/tests/test_trainer.py
@@ -2,7 +2,7 @@
 
 import time
 import logging
-from edgeml.interfaces import TrainerClient, TrainerServer, TrainerConfig
+from edgeml.interfaces import TrainerClient, TrainerServer, TrainerConfig, DataTable
 
 def dummy_training_callback(payload: dict) -> dict:
     """Simulated callback for training data."""
@@ -25,14 +25,21 @@ def test_trainer():
         print("Client received weights:", payload)
 
     # 1. Set up Trainer Server
+    # try make from file method
+    server = TrainerServer.make_from_file(
+        "invalid.pkl", dummy_training_callback, request_callback)
+    assert server is None, "Invalid file should return None"
+
     server_config = TrainerConfig(
             port_number=5555,
             broadcast_port=5556,
-            queue_size=2,
+            data_table=[DataTable(name="table1", size=2),
+                        DataTable(name="table2", size=3)],
             request_types=["get-stats"],
         )
     server = TrainerServer(server_config, dummy_training_callback, request_callback)
     server.start(threaded=True)
+    assert len(server.table_names()) == 2, "Invalid table names in server"
     time.sleep(1)  # Give it a moment to start
 
     # 2. Set up Trainer Client
@@ -41,7 +48,7 @@ def test_trainer():
 
     # 3. Client sends dummy training data
     training_payload = {"data": [1, 2, 3, 4, 5], "time": time.time()}
-    response = client.train_step(training_payload)
+    response = client.train_step("table1", training_payload)
     print("Client received response:", response)
 
     # 4. Custom get stats request
@@ -59,15 +66,22 @@ def test_trainer():
 
     # 6. Server is able to queue up to the max queue size
     training_payload = {"data": [6, 7, 8], "time": time.time()}
-    response = client.train_step(training_payload)
+    response = client.train_step("table1", training_payload)
     training_payload = {"data": [9, 10], "time": time.time()}
-    response = client.train_step(training_payload)
-    datas = server.get_data()
+    response = client.train_step("table1", training_payload)
+    datas = server.get_data("table1")
     print("Server received data:", datas)
     assert len(datas) == 2, "Server should have 2 data points in queue"
     assert datas[0]['data'] == [6, 7, 8], "Server queue should be FIFO"
 
-    # 7. Clean up
+    # 7. check data table size
+    datas = server.get_data("table2")
+    print("Server received data:", server.data_store)
+    assert len(datas) == 0, "Server should have no data points in queue"
+    assert server.get_data("table99") is None, "Invalid table name should return None"
+
+    # 8. Clean up
+    # server.save_data("test.pkl")
     server.stop()
     client.stop()
 

--- a/edgeml/tests/test_trainer.py
+++ b/edgeml/tests/test_trainer.py
@@ -4,9 +4,9 @@ import time
 import logging
 from edgeml.interfaces import TrainerClient, TrainerServer, TrainerConfig, DataTable
 
-def dummy_training_callback(payload: dict) -> dict:
+def dummy_training_callback(table_name, payload: dict) -> dict:
     """Simulated callback for training data."""
-    print("Server received training data:", payload)
+    print("Server received training data:", payload, " for table:", table_name)
     # For the sake of this test, just echo back the data as "weights"
     return {"weights": payload['data']}
 

--- a/example.py
+++ b/example.py
@@ -1,7 +1,7 @@
 # !/usr/bin/env python3
 
 import argparse
-from edgeml.interfaces import ActorClient, ActorServer, ActorConfig
+from edgeml.interfaces import ActionClient, ActionServer, ActionConfig
 import cv2
 import time
 
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=5556)
     args = parser.parse_args()
 
-    config = ActorConfig(
+    config = ActionConfig(
         port_number = args.port,
         action_keys = ["init", "move", "gripper", "reset", "start"],
         observation_keys = ["image", "proprio"],
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     CLIENT_TIMEOUT = 8
 
     if args.server:
-        server = ActorServer(config, obs_callback=obs_callback, act_callback=act_callback)
+        server = ActionServer(config, obs_callback=obs_callback, act_callback=act_callback)
         server.start(threaded=True)
 
         # broadcast observations stream every 1 second
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             server.publish_obs({"depth_image": "test-broadcast publish impl"})
 
     if args.client:
-        client = ActorClient(args.ip, config)
+        client = ActionClient(args.ip, config)
         
         sub_count = 0
         def sub_callback(obs: dict):


### PR DESCRIPTION
- Rename `Actor` to `Action`
  - the naming of `Actor` mode can be confusing. As ref to RL and [acme framework](https://dm-acme.readthedocs.io/en/latest/user/overview.html), the feature of this module should be named as Env. 
  - However, to make its application more general, we rename it `Action`
- Expand the functionality of `Trainer` with more `data_tables` and saving and loading of data.
  - Currently, a fixed FIFO queue is used. Refer to [reverb](https://github.com/google-deepmind/reverb), we can include more advanced features like a uniform sampler, and priority queue for replay buffer in the future.