### PR TITLE
update trainer and datastore abstract class

### DIFF
--- a/edgeml/action.py
+++ b/edgeml/action.py
@@ -11,14 +11,14 @@ from edgeml.internal.utils import compute_hash
 
 import threading
 import logging
-from pydantic import BaseModel
+from dataclasses import dataclass, asdict
 import json
 
 
 ##############################################################################
 
-
-class ActionConfig(BaseModel):
+@dataclass
+class ActionConfig():
     """Configuration for the env server and client
     NOTE: Client and server should have the same config
             client will raise Error if configs are different, thus can use
@@ -74,7 +74,7 @@ class ActionServer:
             elif payload["type"] == "act" and act_callback is not None:
                 return act_callback(payload["key"], payload["payload"])
             elif payload["type"] == "hash":
-                config_json = json.dumps(config.dict(), separators=(',', ':'))
+                config_json = json.dumps(asdict(config), separators=(',', ':'))
                 return {"success": True, "payload": config_json}
             return {"success": False, "message": "Invalid payload"}
 
@@ -124,7 +124,7 @@ class ActionClient:
         if res is None:
             raise Exception("Failed to connect to action server")
 
-        config_json = json.dumps(config.dict(), separators=(',', ':'))
+        config_json = json.dumps(asdict(config), separators=(',', ':'))
         if compute_hash(config_json) != compute_hash(res["payload"]):
             raise Exception(
                 f"Incompatible config with hash with server. "

--- a/edgeml/data/data_store.py
+++ b/edgeml/data/data_store.py
@@ -1,32 +1,30 @@
 #!/usr/bin/env python3
 
 from __future__ import annotations
-from typing import Any, Dict, List, Tuple, Any
+from typing import Any, Dict, List, Tuple, Any, Union
 from collections import deque
 
 from abc import abstractmethod
+from threading import Lock
 
 ##############################################################################
 
 
 class DataStoreBase:
+    def __init__(self, capacity: int):
+        self.capacity = capacity
+
     @abstractmethod
     def latest_data_id() -> Any:
         """Return the id of the latest data"""
         pass
 
     @abstractmethod
-    def get_latest_data(self, from_id: Any) -> Tuple[list, dict]:
+    def get_latest_data(self, from_id: Any) -> List[Any]:
         """
         provide the all data from the given id
-            :return indices of the updated data within the store
-                    and it's corresponding data
+            :return a list of data
         """
-        pass
-
-    @abstractmethod
-    def update_data(self, indices: list, data: dict):
-        """with the indices and data, update the latest data"""
         pass
 
     @abstractmethod
@@ -34,46 +32,62 @@ class DataStoreBase:
         """Length of the valid data in the store"""
         pass
 
+    @abstractmethod
+    def insert(self, data: Any):
+        pass
+
+    def batch_insert(self, batch_data: List[Any]):
+        """
+        Insert a batch of data by using `insert()`
+          :param batch_data: a list of data
+
+        NOTE: override this function to create a more efficient
+        implementation for custom data store, e.g. slicing in np
+        """
+        if len(batch_data) > self.capacity:
+            batch_data = batch_data[-self.capacity:]
+        for data in batch_data:
+            self.insert(data)
+
 ##############################################################################
 
 
 class QueuedDataStore(DataStoreBase):
-    """A simple queue-based data store."""
+    """
+    A simple queue-based data store. This can be used as a simple
+    queue for sending a sequence of data to the trainer server replay buffer
+    """
 
     def __init__(self, capacity: int):
-        self.queue = deque(maxlen=capacity)
+        DataStoreBase.__init__(self, capacity)
+        self._seq_id_queue = deque(maxlen=capacity)
+        self._data_queue = deque(maxlen=capacity)
         self.latest_seq_id = -1
+        self._lock = Lock()
 
     def latest_data_id(self) -> int:
         return self.latest_seq_id
 
     def insert(self, data: Any):
+        self._lock.acquire()
         self.latest_seq_id += 1
-        self.queue.append((self.latest_seq_id, data))
+        self._seq_id_queue.append(self.latest_seq_id)
+        self._data_queue.append(data)
+        self._lock.release()
 
-    def get_latest_data(self, from_id: int) -> Tuple[List[int], Dict]:
-        indices = []
-        output_data = {"seq_id": [], "data": []}
-
-        for idx, (seq_id, data) in enumerate(self.queue):
-            if seq_id > from_id:
-                indices.append(idx)
-                output_data["seq_id"].append(seq_id)
-                output_data["data"].append(data)
-
-        return indices, output_data
-
-    def update_data(self, indices: List[int], data: Dict):
-        assert len(indices) == len(data["seq_id"]) == len(data["data"])
-        for i, idx in enumerate(indices):
-            _id, _data = data["seq_id"][i], data["data"][i]
-            if idx < len(self.queue):
-                self.queue[idx] = (_id, _data)
-            else:
-                self.queue.append((_id, _data))
-        # the last data is always the latest
-        if len(self.queue) > 0:
-            self.latest_seq_id = self.queue[-1][0]
+    def get_latest_data(self, from_id: int) -> List[Any]:
+        self._lock.acquire()
+        return_data = []
+        if not self._seq_id_queue or from_id >= self.latest_seq_id:
+            pass
+        elif from_id < self._seq_id_queue[0]:
+            return_data = list(self._data_queue)
+        else:
+            # calc the index where the required data starts in the queue.
+            start_idx = from_id - self._seq_id_queue[0] + 1
+            return_data = list(self._data_queue)[start_idx:]
+        self._lock.release()
+        return return_data
 
     def __len__(self):
-        return len(self.queue)
+        return len(self._seq_id_queue)

--- a/edgeml/tests/test_action.py
+++ b/edgeml/tests/test_action.py
@@ -23,10 +23,10 @@ def test_action():
 
     # Define our config
     config = ActionConfig(
-        port_number=5555,
+        port_number=5588,
         action_keys=['send_image'],
         observation_keys=['test_image'],
-        broadcast_port=5556
+        broadcast_port=5589,
     )
 
     # Initialize and start the ActionServer in a separate thread

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
         'zmq',
         'typing',
         'typing_extensions',
-        'pydantic',
         'opencv-python',
         'lz4',
     ],


### PR DESCRIPTION
1) Re-draft `DataStoreBase` abstract class impl

This will be compatible to [jaxrl2's replaybuffer](https://github.com/ikostrikov/jaxrl2/blob/main/jaxrl2/data/replay_buffer.py). By adding inherit `DataStoreBase`

```py
class ReplayBuffer(Dataset, DataStoreBase):
        DataStoreBase.__init__(self, capacity)
```

The current design support the usage of mixing different datastore:

```bash
[Queue based data store]   ----- enabled by edgeml trainer transport --->   [Replay buffer datastore]
```

This helps in reducing the copies of data in different datastore if strict replication is not required.


2) code cleanup, remove usage of pydantic, etc
3) the current `data/replay_buffer.py` requires some rework, in progress https://github.com/youliangtan/edgeml/pull/11
