### PR TITLE
gym sac example with jaxrl_m

### DIFF
--- a/edgeml/trainer.py
+++ b/edgeml/trainer.py
@@ -285,19 +285,17 @@ class TrainerTunnel:
         NOTE: this suppose to be an experimental feature
     """
     def __init__(self):
-        self.recv_network_fn = None
-        self.request_callback = None
+        self._recv_network_fn = None
+        self._req_callback_fn = None
 
-    # NOTE: Method for TrainerClient
-    def recv_network_callback(self, function):
+    def recv_network_callback(self, callback_fn: Callable):
         """Refer to TrainerClient.recv_network_callback()"""
-        self.recv_network_fn = function
+        self._recv_network_fn = callback_fn
 
-    # NOTE: Method for TrainerServer
-    def publish_network(self, params):
+    def publish_network(self, params: dict):
         """Refer to TrainerClient.recv_network_callback()"""
-        if self.recv_network_fn:
-            self.recv_network_fn(params)
+        if self._recv_network_fn:
+            self._recv_network_fn(params)
 
     def start(self, *args, **kwargs):
         pass # Do nothing
@@ -307,13 +305,21 @@ class TrainerTunnel:
 
     def update(self):
         """Refer to TrainerClient.update()"""
-        pass # Do nothing
+        pass # Do nothing since assume shared datastore
 
-    def register_request_callback(self, callback):
+    def register_request_callback(self, callback_fn: Callable):
         """A impl within TrainerServer.init()"""
-        self.request_callback = callback
+        self._req_callback_fn = callback_fn
 
-    def request(self, type, payload):
+    def request(self, type: str, payload: dict) -> Optional[dict]:
         """Refer to TrainerClient.request()"""
-        if self.request_callback:
-            self.request_callback(type, payload)
+        if self._req_callback_fn:
+            return self._req_callback_fn(type, payload)
+        return None
+    
+    def start_async_update(self, interval: int = 10):
+        """
+        Refer to TrainerClient.start_async_update()
+        no impl needed since assume shared datastore
+        """
+        pass

--- a/edgeml/trainer.py
+++ b/edgeml/trainer.py
@@ -274,3 +274,46 @@ class TrainerClient:
             self.stop_update_flag.set()
             self.update_thread.join()
         logging.debug("Stopped trainer client")
+
+##############################################################################
+
+class TrainerTunnel:
+    """
+    This is a simple implementation to recreate the transport layer interface
+    of TrainerServer and TrainerClient. Helpful to test multithreaded operation
+    for TrainerServer and TrainerClient, while sharing the same datastore.
+        NOTE: this suppose to be an experimental feature
+    """
+    def __init__(self):
+        self.recv_network_fn = None
+        self.request_callback = None
+
+    # NOTE: Method for TrainerClient
+    def recv_network_callback(self, function):
+        """Refer to TrainerClient.recv_network_callback()"""
+        self.recv_network_fn = function
+
+    # NOTE: Method for TrainerServer
+    def publish_network(self, params):
+        """Refer to TrainerClient.recv_network_callback()"""
+        if self.recv_network_fn:
+            self.recv_network_fn(params)
+
+    def start(self, *args, **kwargs):
+        pass # Do nothing
+
+    def stop(self):
+        pass # Do nothing
+
+    def update(self):
+        """Refer to TrainerClient.update()"""
+        pass # Do nothing
+
+    def register_request_callback(self, callback):
+        """A impl within TrainerServer.init()"""
+        self.request_callback = callback
+
+    def request(self, type, payload):
+        """Refer to TrainerClient.request()"""
+        if self.request_callback:
+            self.request_callback(type, payload)

--- a/examples/async_learner_actor.py
+++ b/examples/async_learner_actor.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+
+# NOTE: this requires jaxrl_m to be installed: 
+#       https://github.com/rail-berkeley/jaxrl_minimal
+
+import time
+from functools import partial
+
+import gym
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tqdm
+from absl import app, flags
+from flax import linen as nn
+from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
+
+from jaxrl_m.agents.continuous.sac import SACAgent
+from jaxrl_m.common.evaluation import evaluate
+from jaxrl_m.utils.timer_utils import Timer
+
+from edgeml.trainer import TrainerServer, TrainerClient, TrainerTunnel
+from edgeml.data.data_store import QueuedDataStore
+
+from jaxrl_common import ReplayBufferDataStore
+from jaxrl_common import make_agent, make_trainer_config, make_wandb_logger
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("env", "HalfCheetah-v4", "Name of environment.")
+flags.DEFINE_string("agent", "sac", "Name of agent.")
+flags.DEFINE_string("exp_name", None, "Name of the experiment for wandb logging.")
+flags.DEFINE_integer("max_traj_length", 1000, "Maximum length of trajectory.")
+flags.DEFINE_integer("seed", 42, "Random seed.")
+flags.DEFINE_bool("save_model", False, "Whether to save model.")
+flags.DEFINE_integer("batch_size", 256, "Batch size.")
+flags.DEFINE_integer("utd_ratio", 8, "UTD ratio.")
+
+flags.DEFINE_integer("max_steps", 1000000, "Maximum number of training steps.")
+flags.DEFINE_integer("replay_buffer_capacity", 1000000, "Replay buffer capacity.")
+
+flags.DEFINE_integer("random_steps", 500, "Sample random actions for this many steps.")
+flags.DEFINE_integer("training_starts", 1000, "Training starts after this step.")
+flags.DEFINE_integer("steps_per_update", 10, "Number of steps per update the server.")
+
+flags.DEFINE_integer("log_period", 10, "Logging period.")
+flags.DEFINE_integer("eval_period", 10000, "Evaluation period.")
+flags.DEFINE_integer("eval_n_trajs", 5, "Number of trajectories for evaluation.")
+
+# flag to indicate if this is a leaner or a actor
+flags.DEFINE_boolean("learner", False, "Is this a learner or a trainer.")
+flags.DEFINE_boolean("actor", False, "Is this a learner or a trainer.")
+
+
+def print_green(x): return print("\033[92m {}\033[00m" .format(x))
+
+##############################################################################
+
+
+def actor(agent: SACAgent, data_store, env, sampling_rng, tunnel=None):
+    """
+    This is the actor loop, which runs when "--actor" is set to True.
+        NOTE: tunnel is used the transport layer for multi-threading
+    """
+    if tunnel:
+        client = tunnel
+    else:
+        client = TrainerClient(
+            "actor_env", "localhost",
+            make_trainer_config(),
+            data_store,
+            wait_for_server=True,
+        )
+
+    # Function to update the agent with new params
+    def update_params(params):
+        nonlocal agent
+        # chex.assert_trees_all_equal_shapes(params, agent.state.params)
+        agent = agent.replace(state=agent.state.replace(params=params))
+
+    client.recv_network_callback(update_params)
+
+    eval_env = gym.make(FLAGS.env)
+    eval_env = RecordEpisodeStatistics(eval_env)
+
+    obs, _ = env.reset()
+    done = False
+
+    # training loop
+    timer = Timer()
+    running_return = 0.0
+    for step in tqdm.tqdm(range(FLAGS.max_steps), dynamic_ncols=True):
+        timer.tick("total")
+
+        with timer.context("sample_actions"):
+            if step < FLAGS.random_steps:
+                actions = env.action_space.sample()
+            else:
+                sampling_rng, key = jax.random.split(sampling_rng)
+                actions = agent.sample_actions(
+                    observations=jax.device_put(obs),
+                    seed=key,
+                    deterministic=False,
+                )
+                actions = np.asarray(jax.device_get(actions))
+
+        # Step environment
+        with timer.context("step_env"):
+
+            next_obs, reward, done, truncated, info = env.step(actions)
+            next_obs = np.asarray(next_obs, dtype=np.float32)
+            reward = np.asarray(reward, dtype=np.float32)
+            info = np.asarray(info)
+            running_return += reward
+
+            data_store.insert(
+                dict(
+                    observations=obs,
+                    actions=actions,
+                    next_observations=next_obs,
+                    rewards=reward,
+                    masks=1.0 - done,
+                )
+            )
+
+            obs = next_obs
+            if done or truncated:
+                running_return = 0.0
+                obs, _ = env.reset()
+
+        if step % FLAGS.steps_per_update == 0:
+            client.update()
+
+        if step % FLAGS.eval_period == 0:
+            with timer.context("eval"):
+                evaluate_info = evaluate(
+                    policy_fn=partial(agent.sample_actions, argmax=True),
+                    env=eval_env,
+                    num_episodes=FLAGS.eval_n_trajs,
+                )
+            stats = {"eval": evaluate_info}
+            client.request("send-stats", stats)
+
+        timer.tock("total")
+
+        if step % FLAGS.log_period == 0:
+            stats = {"timer": timer.get_average_times()}
+            client.request("send-stats", stats)
+
+##############################################################################
+
+
+def learner(agent, replay_buffer, wandb_logger=None, tunnel=None):
+    """
+    The learner loop, which runs when "--learner" is set to True.
+    NOTE: tunnel is used the transport layer for multi-threading
+    """
+    # To track the step in the training loop
+    update_steps = 0
+
+    def stats_callback(type: str, payload: dict) -> dict:
+        """Callback for when server receives stats request."""
+        assert type == "send-stats", f"Invalid request type: {type}"
+        if wandb_logger is not None:
+            wandb_logger.log(payload, step=update_steps)
+        return {}
+
+    # Create server
+    if tunnel:
+        tunnel.register_request_callback(stats_callback)
+        server = tunnel
+    else:
+        server = TrainerServer(make_trainer_config(), request_callback=stats_callback)
+        server.register_data_store("actor_env", replay_buffer)
+        server.start(threaded=True)
+
+    # wait till the replay buffer is filled with enough data
+    while len(replay_buffer) < FLAGS.training_starts:
+        print(f"waiting for replay buffer to fill up, current size: \
+            {len(replay_buffer)}/{FLAGS.training_starts}")
+        time.sleep(2)
+
+    # send the initial network to the actor
+    server.publish_network(agent.state.params)
+    print_green('sent initial network to actor')
+
+    # wait till the replay buffer is filled with enough data
+    timer = Timer()
+    for step in tqdm.tqdm(range(FLAGS.max_steps), dynamic_ncols=True):
+        # Train the networks
+        with timer.context("sample_replay_buffer"):
+            batch = replay_buffer.sample(FLAGS.batch_size * FLAGS.utd_ratio)
+
+        with timer.context("train"):
+            agent, update_info = agent.update_high_utd(
+                batch, utd_ratio=FLAGS.utd_ratio
+            )
+            agent = jax.block_until_ready(agent)
+
+            # publish the updated network
+            server.publish_network(agent.state.params)
+
+        if update_steps % FLAGS.log_period == 0 and wandb_logger:
+            wandb_logger.log(update_info, step=update_steps)
+            wandb_logger.log({"timer": timer.get_average_times()}, step=update_steps)
+        update_steps += 1
+
+##############################################################################
+
+
+def main(_):
+    devices = jax.local_devices()
+    num_devices = len(devices)
+    sharding = jax.sharding.PositionalSharding(devices)
+    assert FLAGS.batch_size % num_devices == 0
+
+    # seed
+    rng = jax.random.PRNGKey(FLAGS.seed)
+
+    # create env and load dataset
+    env = gym.make(FLAGS.env)
+
+    rng, sampling_rng = jax.random.split(rng)
+    agent: SACAgent = make_agent(
+        sample_obs=env.observation_space.sample(),
+        sample_action=env.action_space.sample(),
+    )
+
+    # replicate agent across devices
+    # need the jnp.array to avoid a bug where device_put doesn't recognize primitives
+    agent: SACAgent = jax.device_put(
+        jax.tree_map(jnp.array, agent), sharding.replicate()
+    )
+
+    def create_replay_buffer_and_wandb_logger():
+        replay_buffer = ReplayBufferDataStore(
+            env.observation_space,
+            env.action_space,
+            capacity=FLAGS.replay_buffer_capacity,
+        )
+
+        # set up wandb and logging
+        wandb_logger = make_wandb_logger(
+            project="jaxrl_minimal",
+            description=FLAGS.exp_name or FLAGS.env,
+        )
+        return replay_buffer, wandb_logger
+
+    if FLAGS.learner:
+        replay_buffer, wandb_logger = create_replay_buffer_and_wandb_logger()
+
+        # learner loop
+        print_green("starting learner loop")
+        learner(agent, replay_buffer, wandb_logger=wandb_logger, tunnel=None)
+
+    elif FLAGS.actor:
+        sampling_rng = jax.device_put(sampling_rng, sharding.replicate())
+        data_store = QueuedDataStore(50000)  # the queue size on the actor
+
+        # actor loop
+        print_green("starting actor loop")
+        actor(agent, data_store, env, sampling_rng, tunnel=None)
+
+    else:
+        print_green("starting actor and learner loop with multi-threading")
+
+        # In this example, the tunnel acts as the transport layer for the
+        # trainerServer and trainerClient. Also, both actor and learner shares
+        # the same replay buffer.
+        replay_buffer, wandb_logger = create_replay_buffer_and_wandb_logger()
+
+        tunnel = TrainerTunnel()
+        sampling_rng = jax.device_put(sampling_rng, sharding.replicate())
+
+        import threading
+        # Start learner thread
+        learner_thread = threading.Thread(
+            target=learner,
+            args=(agent, replay_buffer, wandb_logger, tunnel)
+        )
+        learner_thread.start()
+
+        # Start actor in main process
+        actor(agent, replay_buffer, env, sampling_rng, tunnel=tunnel)
+        learner_thread.join()
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/examples/jaxrl_common.py
+++ b/examples/jaxrl_common.py
@@ -1,0 +1,110 @@
+# !/usr/bin/env python3
+
+# NOTE: this requires jaxrl_m to be installed: 
+#       https://github.com/rail-berkeley/jaxrl_minimal
+
+import jax
+import gym
+
+from jaxrl_m.agents.continuous.sac import SACAgent
+from jaxrl_m.common.wandb import WandBLogger
+
+from edgeml.trainer import TrainerConfig
+from edgeml.data.data_store import DataStoreBase
+
+from jaxrl_m.common.wandb import WandBLogger
+from jaxrl_m.agents.continuous.sac import SACAgent
+from jaxrl_m.data.replay_buffer import ReplayBuffer
+from edgeml.trainer import TrainerConfig
+
+from threading import Lock
+
+from jax import nn
+
+##############################################################################
+
+
+class ReplayBufferDataStore(ReplayBuffer, DataStoreBase):
+    def __init__(
+        self,
+        observation_space: gym.Space,
+        action_space: gym.Space,
+        capacity: int,
+    ):
+        ReplayBuffer.__init__(self, observation_space, action_space, capacity)
+        DataStoreBase.__init__(self, capacity)
+        self._lock = Lock()
+
+    # ensure thread safety
+    def insert(self, *args, **kwargs):
+        with self._lock:
+            super(ReplayBufferDataStore, self).insert(*args, **kwargs)
+
+    # ensure thread safety
+    def sample(self, *args, **kwargs):
+        with self._lock:
+            return super(ReplayBufferDataStore, self).sample(*args, **kwargs)
+
+    # NOTE: method for DataStoreBase
+    def latest_data_id(self):
+        return self._insert_index
+
+    # NOTE: method for DataStoreBase
+    def get_latest_data(self, from_id: int):
+        raise NotImplementedError  # TODO
+
+
+##############################################################################
+
+
+def make_agent(sample_obs, sample_action):
+    return SACAgent.create_states(
+        jax.random.PRNGKey(0),
+        sample_obs,
+        sample_action,
+        policy_kwargs={
+            "tanh_squash_distribution": True,
+            "std_parametrization": "softplus",
+        },
+        critic_network_kwargs={
+            "activations": nn.tanh,
+            "use_layer_norm": True,
+            "hidden_dims": [256, 256],
+        },
+        policy_network_kwargs={
+            "activations": nn.tanh,
+            "use_layer_norm": True,
+            "hidden_dims": [256, 256],
+        },
+        temperature_init=1e-2,
+        discount=0.99,
+        backup_entropy=True,
+        critic_ensemble_size=10,
+        critic_subsample_size=2,
+    )
+
+
+def make_trainer_config():
+    return TrainerConfig(
+        port_number=5588,
+        broadcast_port=5589,
+        request_types=["send-stats"]
+    )
+
+
+def make_wandb_logger(
+    project: str = "edgeml",
+    description: str = "jaxrl_m",
+):
+    wandb_config = WandBLogger.get_default_config()
+    wandb_config.update(
+        {
+            "project": project,
+            "exp_descriptor": description,
+        }
+    )
+    wandb_logger = WandBLogger(
+        wandb_config=wandb_config,
+        variant={},
+    )
+    return wandb_logger

--- a/examples/jaxrl_m_common.py
+++ b/examples/jaxrl_m_common.py
@@ -86,8 +86,8 @@ def make_agent(sample_obs, sample_action):
 
 def make_trainer_config():
     return TrainerConfig(
-        port_number=5588,
-        broadcast_port=5589,
+        port_number=5488,
+        broadcast_port=5489,
         request_types=["send-stats"]
     )
 


### PR DESCRIPTION
## TLDR

This PR provides an example to run the half cheetah example with async training.

- Requires: https://github.com/rail-berkeley/jaxrl_minimal  (close sourced for now)

## Quick Runs

**1. Run 2 processes (learner and actor)**

Run Learner, a server which runs gradient update
```bash
python3 examples/async_learner_actor.py --learner
```

Run Actor, an agent which runs env updates, provides new obs to server, and receives new weights
```
python3 examples/async_learner_actor.py --actor
```

**2. With Async multi-threading. (Mainly for testing)**

```bash
python3 examples/async_learner_actor.py
```

## My current test

With the current setup, it takes around 1000 gradient steps before the actor loss starts going down. Q value will also go up after 1k steps. This is tested on a CPU, which is obviously slow for each gradient update. TODO: test on GPU env.
