### PR TITLE
Fix async example bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.py[cod]
 *.so
 *.pyc
+wandb/

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ python3 examples/simple_replay_buffer.py
 ## then try out --server and --client mode on 2 separate terminals
 ```
 
-3. Async learner-actor with Gym RL env (required `jaxrl_m` as dependency)
+3. Async learner-actor with Gym RL env (requires `jaxrl_m` as dependency)
 
 ```bash
-# indicate --learner or --actor mode, no tag means async multithreaded mode
+# Indicate --learner or --actor mode, no tag means async multithreaded mode
+# provide --ip for remote connection, default is localhost
+# use --render to render the gym env
 python3 examples/async_learner_actor.py
 ```
 

--- a/edgeml/zmq_wrapper/broadcast.py
+++ b/edgeml/zmq_wrapper/broadcast.py
@@ -16,6 +16,7 @@ class BroadcastServer:
                  compression: str = 'lz4'):
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.PUB)
+        self.socket.setsockopt(zmq.SNDHWM, 3)  # queue size 3 for send buffer
         self.socket.bind(f"tcp://*:{port}")
         self.compress, _ = make_compression_method(compression)
         logging.basicConfig(level=log_level)
@@ -42,9 +43,15 @@ class BroadcastClient:
         _, self.decompress = make_compression_method(comppression)
         # Set a timeout for the recv method (e.g., 1.5 second)
         self.socket.setsockopt(zmq.RCVTIMEO, 1500)
+
+        # ZMQ will queue up msg with slow connections. This resulted in
+        # the new weights update being queued up, actor is not able to learn
+        # https://stackoverflow.com/questions/59542620/zmq-drop-old-messages
+        self.socket.setsockopt(zmq.CONFLATE, 1)
+        self.socket.setsockopt(zmq.RCVHWM, 3)  # queue size 3 for receive buffer
         self.is_kill = False
         self.thread = None
-            
+
     def async_start(self, callback: Callable[[dict], None]):
         def async_listen():
             while not self.is_kill:

--- a/edgeml/zmq_wrapper/broadcast.py
+++ b/edgeml/zmq_wrapper/broadcast.py
@@ -45,9 +45,9 @@ class BroadcastClient:
         self.socket.setsockopt(zmq.RCVTIMEO, 1500)
 
         # ZMQ will queue up msg with slow connections. This resulted in
-        # the new weights update being queued up, actor is not able to learn
+        # the new updated weights being queued up, actor is not able to learn
         # https://stackoverflow.com/questions/59542620/zmq-drop-old-messages
-        self.socket.setsockopt(zmq.CONFLATE, 1)
+        self.socket.setsockopt(zmq.CONFLATE, True)
         self.socket.setsockopt(zmq.RCVHWM, 3)  # queue size 3 for receive buffer
         self.is_kill = False
         self.thread = None

--- a/examples/jaxrl_m_common.py
+++ b/examples/jaxrl_m_common.py
@@ -64,7 +64,7 @@ def make_agent(sample_obs, sample_action):
         sample_action,
         policy_kwargs={
             "tanh_squash_distribution": True,
-            "std_parametrization": "softplus",
+            "std_parameterization": "softplus",
         },
         critic_network_kwargs={
             "activations": nn.tanh,


### PR DESCRIPTION
## Summary

Fixed some bugs, and make the `examples/simple_replay_buffer.py` more usable

1. Single process
```sh
python3 examples/simple_replay_buffer.py
```

2. Remote actor and learner
```sh
# Learner
python3 examples/async_learner_actor.py --learner
```

```sh
# Actor, with IP, and render the mujuco gym env
python3 examples/async_learner_actor.py --ip 100.78.214.136 --actor --render
```

## Notes for Delayed network update bug

Just to keep this as a note. When conducting remote training, the actor loss plateaued (shown in the graph below, async single/multi-processes on single machine work perfectly). This is due to the high rate of publishing the updated network weights to subscribers and the zmq sub is queuing "old" network weights. Thus changing the qos to keep last only solves this issue.

![Screenshot from 2023-10-31 23-30-33](https://github.com/youliangtan/edgeml/assets/32189404/f24a3adb-a0c9-42de-9c79-4dcc7402400b)



